### PR TITLE
handle chunked json on changes feed

### DIFF
--- a/lib/coax.js
+++ b/lib/coax.js
@@ -32,6 +32,7 @@ Coax.extend("changes", function(opts, cb) {
   var self = this;
   opts = opts || {};
 
+
   if (opts.feed == "continuous") {
     var listener = self(["_changes", opts], function(err, ok) {
       if (err && err.code == "ETIMEDOUT") {
@@ -41,9 +42,19 @@ Coax.extend("changes", function(opts, cb) {
       }
     });
     listener.on("data", function(data){
-      var json = JSON.parse(data);
+      var sep = "\n";
+
+      // re-emit chunked json data
+      eom = data.toString().indexOf(sep)
+      msg = data.toString().substring(0, eom)
+      remaining = data.toString().substring(eom + 1, data.length)
+      if (remaining.length > 0){
+        console.log(data.toString())
+        listener.emit("data", remaining)
+      }
+
+      var json = JSON.parse(msg);
       cb(false, json)
-      // console.log("data", data.toString())
     })
     return listener;
   } else {


### PR DESCRIPTION
sometimes changes feed will return responses that lead to syntax errors in normal parsing by chunking
more than one message together:
{"seq":190,"id":"FC084D00-3F53-4986-AFC3-BD6216921DE7","changes":[{"rev":"1-9ac8ecffeaaab2996a78862dcdceaa94"}]}
{"seq":191,"id":"34EE6153-BEC7-4A6F-AE4F-2BF499B9DA3F","changes":[{"rev":"1-ecf8e9fbd31269d84967f6480c84e787"}]}
this is an attempt to parse are re-emit these as separate events
